### PR TITLE
modify eventlastvalue to send along the whole record

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ With a conf like
 You would get
 
 ```
-output.lastvalue { 'id': 12345, 'count': 6 }
-output.lastvalue { 'id': 1337, 'count': 28 }
-output.lastvalue { 'id': 33864, 'count': 24 }
-output.lastvalue { 'id': 40555, 'count': 18 }
+output.lastvalue { 'id': 12345, 'count': 6, 'time': 1413544860 }
+output.lastvalue { 'id': 1337, 'count': 28, 'time': 1413544890 }
+output.lastvalue { 'id': 33864, 'count': 24, 'time': 1413544830 }
+output.lastvalue { 'id': 40555, 'count': 18, 'time': 1413544890 }
 ```
 
 ##Installation
@@ -55,11 +55,11 @@ or
 
 #### Basic
 
-- **id_key** (**required**)
+- **id_key** (**default**:id)
     - The key within the record that identifies a group of events to select from.
 
-- **last_value_key** (**required**)
-    - the key from whose values we want to record the last
+- **last_value_key** (optional)
+    - the key from whose values we want to record the last, if present records sent that do not contain the key will be excluded.
 
 - **emit_to** (optional) - *string*
     - Tag to re-emit with

--- a/lib/fluent/plugin/out_eventlastvalue.rb
+++ b/lib/fluent/plugin/out_eventlastvalue.rb
@@ -6,7 +6,7 @@ class Fluent::EventLastValueOutput < Fluent::BufferedOutput
 
   config_param :emit_to, :string, :default => 'debug.events'
   config_param :id_key, :string, :default => 'id'
-  config_param :last_value_key, :string # REQUIRED
+  config_param :last_value_key, :string, :default => nil
   config_param :comparator_key, :string, :default => nil
 
   attr_accessor :last_values
@@ -20,8 +20,8 @@ class Fluent::EventLastValueOutput < Fluent::BufferedOutput
   end
 
   def format(tag, time, record)
-    return '' unless record[@last_value_key]
-    [record[@id_key], record[@last_value_key], (record[@comparator_key] || 0).to_f].to_json + "\n"
+    return '' unless @last_value_key && record[@last_value_key]
+    [record[@id_key], record, (record[@comparator_key] || 0).to_f].to_json + "\n"
   end
 
   def write(chunk)
@@ -38,8 +38,8 @@ class Fluent::EventLastValueOutput < Fluent::BufferedOutput
       end
     end
 
-    last_values.each do |key, value|
-      Fluent::Engine.emit(@emit_to, Time.now.to_i, @id_key => key, @last_value_key => value, 'ts' => Time.now.to_s)
+    last_values.each do |key, last_record|
+      Fluent::Engine.emit(@emit_to, Time.now.to_i, last_record)
     end
   end
 end

--- a/spec/out_eventlastvalue_spec.rb
+++ b/spec/out_eventlastvalue_spec.rb
@@ -16,9 +16,11 @@ describe Fluent::EventLastValueOutput do
     let (:eventlastvalue) { Fluent::Test::BufferedOutputTestDriver.new(Fluent::EventLastValueOutput.new).configure(conf) }
     context 'the input contains the last_value key' do
       it 'produces the expected output' do
+        record = { 'id' => '4444', 'timestamp' => 123456789, 'count' => 12345 }
+
         eventlastvalue.tag = 'something'
-        eventlastvalue.emit( { 'id' => '4444', 'timestamp' => 123456789, 'count' => 12345 }, Time.now )
-        eventlastvalue.expect_format ["4444", 12345, 123456789].to_json + "\n"
+        eventlastvalue.emit( record, Time.now )
+        eventlastvalue.expect_format ["4444", record, record['timestamp'].to_f].to_json + "\n"
         eventlastvalue.run
       end
     end
@@ -58,7 +60,7 @@ describe Fluent::EventLastValueOutput do
         data = JSON.parse line
         eventlastvalue.emit data, Time.now
         output = eventlastvalue.run
-        expect(output['1234']).to eq 12345
+        expect(output['1234']).to eq data
       end
 
       it "returns the latest count given the comparator key" do
@@ -66,9 +68,9 @@ describe Fluent::EventLastValueOutput do
           data = JSON.parse line
           eventlastvalue.emit data, Time.now
         end
-
+        expected = {"email" => "john.doe@example.com", "count" => 12340, "timestamp" => "6", "input_id" => "1234"}
         output = eventlastvalue.run
-        expect(output['1234']).to eq 12340
+        expect(output['1234']).to eq expected
       end
     end
 
@@ -87,9 +89,9 @@ describe Fluent::EventLastValueOutput do
           data = JSON.parse line
           eventlastvalue.emit data, Time.now
         end
-
+        expected = {"email"=>"john.doe@example.com", "count"=>12349, "timestamp"=>"5", "input_id"=>"1234"}
         output = eventlastvalue.run
-        expect(output['1234']).to eq 12349
+        expect(output['1234']).to eq expected
       end
     end
   end


### PR DESCRIPTION
Rather than just submitting the selected keys in the output.