### PR TITLE
Adopt for v0.14 compat layer

### DIFF
--- a/fluent-plugin-eventlastvalue.gemspec
+++ b/fluent-plugin-eventlastvalue.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
+  gem.add_development_dependency "test-unit", "~> 3.2.0"
 end

--- a/lib/fluent/plugin/out_eventlastvalue.rb
+++ b/lib/fluent/plugin/out_eventlastvalue.rb
@@ -4,6 +4,11 @@ class Fluent::EventLastValueOutput < Fluent::BufferedOutput
     super
   end
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   config_param :emit_to, :string, :default => 'debug.events'
   config_param :id_key, :string, :default => 'id'
   config_param :last_value_key, :string, :default => nil
@@ -39,7 +44,7 @@ class Fluent::EventLastValueOutput < Fluent::BufferedOutput
     end
 
     last_values.each do |key, last_record|
-      Fluent::Engine.emit(@emit_to, Time.now.to_i, last_record)
+      router.emit(@emit_to, Time.now.to_i, last_record)
     end
   end
 end


### PR DESCRIPTION
Otherwise, the following errors occurred:

```log
% bundle exec rspec spec/out_eventlastvalue_spec.rb          (git)[master]-[OK]
F.FFF

Failures:

  1) Fluent::EventLastValueOutput#format the input contains the last_value key produces the expected output
     Failure/Error: eventlastvalue.run
     RuntimeError:
       BUG: use router.emit instead of Engine.emit
     # ./lib/fluent/plugin/out_eventlastvalue.rb:42:in `block in write'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `each'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `write'
     # ./spec/out_eventlastvalue_spec.rb:24:in `block (4 levels) in <top (required)>'

  2) Fluent::EventLastValueOutput output a comparator key is specified formats the lastvalue against the provided tag
     Failure/Error: output = eventlastvalue.run
     RuntimeError:
       BUG: use router.emit instead of Engine.emit
     # ./lib/fluent/plugin/out_eventlastvalue.rb:42:in `block in write'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `each'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `write'
     # ./spec/out_eventlastvalue_spec.rb:62:in `block (4 levels) in <top (required)>'

  3) Fluent::EventLastValueOutput output a comparator key is specified returns the latest count given the comparator key
     Failure/Error: output = eventlastvalue.run
     RuntimeError:
       BUG: use router.emit instead of Engine.emit
     # ./lib/fluent/plugin/out_eventlastvalue.rb:42:in `block in write'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `each'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `write'
     # ./spec/out_eventlastvalue_spec.rb:72:in `block (4 levels) in <top (required)>'

  4) Fluent::EventLastValueOutput output a comparator key is NOT specified returns the last received count
     Failure/Error: output = eventlastvalue.run
     RuntimeError:
       BUG: use router.emit instead of Engine.emit
     # ./lib/fluent/plugin/out_eventlastvalue.rb:42:in `block in write'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `each'
     # ./lib/fluent/plugin/out_eventlastvalue.rb:41:in `write'
     # ./spec/out_eventlastvalue_spec.rb:93:in `block (4 levels) in <top (required)>'

Finished in 2.65 seconds
5 examples, 4 failures

Failed examples:

rspec ./spec/out_eventlastvalue_spec.rb:18 # Fluent::EventLastValueOutput#format the input contains the last_value key produces the expected output
rspec ./spec/out_eventlastvalue_spec.rb:58 # Fluent::EventLastValueOutput output a comparator key is specified formats the lastvalue against the provided tag
rspec ./spec/out_eventlastvalue_spec.rb:66 # Fluent::EventLastValueOutput output a comparator key is specified returns the latest count given the comparator key
rspec ./spec/out_eventlastvalue_spec.rb:87 # Fluent::EventLastValueOutput output a comparator key is NOT specified returns the last received count
```